### PR TITLE
Change pod management policy to parallel

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -3,7 +3,7 @@ name: rabbitmq
 description: A central RabbitMQ message broker
 type: application
 
-version: 0.2.1
+version: 0.3.0
 
 dependencies:
   - name: rabbitmq

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -1,6 +1,7 @@
 rabbitmq:
   enabled: true
   replicaCount: 3
+  podManagementPolicy: Parallel
   networkPolicy:
     enabled: false
   service:


### PR DESCRIPTION
depends on #9 

`podManagementPolicy="Parallel"` seems to be suggested way to run RabbitMQ on kubernetes and avoids issues when rebooting RMQ nodes.

Following recommendations mentioned here
https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
https://www.rabbitmq.com/docs/clustering#restarting
https://www.rabbitmq.com/docs/cluster-formation#peer-discovery-k8s